### PR TITLE
chore: add shared Renovate config

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -1,0 +1,4 @@
+{
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "extends": ["github>Boshen/renovate"]
+}


### PR DESCRIPTION
## Summary
- add or normalize `.github/renovate.json`
- make `github>Boshen/renovate` the first Renovate preset

## Verification
- parsed `.github/renovate.json` with `jq`
- verified `.extends[0] == "github>Boshen/renovate"`