### PR TITLE
feat: add `with_severity_prefix` config option

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -472,6 +472,7 @@ pub struct Config {
     tab_width: usize,
     char_set: CharSet,
     index_type: IndexType,
+    kind_prefix: bool,
 }
 
 impl Config {
@@ -540,6 +541,13 @@ impl Config {
         self.index_type = index_type;
         self
     }
+    /// Should the report kind prefix (e.g. `Error:`, `Warning:`) be shown in the header?
+    ///
+    /// If unspecified, this defaults to [`true`].
+    pub const fn with_kind_prefix(mut self, kind_prefix: bool) -> Self {
+        self.kind_prefix = kind_prefix;
+        self
+    }
 
     fn error_color(&self) -> Option<Color> {
         Some(Color::Red).filter(|_| self.color)
@@ -591,6 +599,7 @@ impl Config {
             tab_width: 4,
             char_set: CharSet::Unicode,
             index_type: IndexType::Char,
+            kind_prefix: true,
         }
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -472,7 +472,7 @@ pub struct Config {
     tab_width: usize,
     char_set: CharSet,
     index_type: IndexType,
-    kind_prefix: bool,
+    severity_prefix: bool,
 }
 
 impl Config {
@@ -541,11 +541,11 @@ impl Config {
         self.index_type = index_type;
         self
     }
-    /// Should the report kind prefix (e.g. `Error:`, `Warning:`) be shown in the header?
+    /// Should the severity prefix (e.g. `Error:`, `Warning:`) be shown in the header?
     ///
     /// If unspecified, this defaults to [`true`].
-    pub const fn with_kind_prefix(mut self, kind_prefix: bool) -> Self {
-        self.kind_prefix = kind_prefix;
+    pub const fn with_severity_prefix(mut self, severity_prefix: bool) -> Self {
+        self.severity_prefix = severity_prefix;
         self
     }
 
@@ -599,7 +599,7 @@ impl Config {
             tab_width: 4,
             char_set: CharSet::Unicode,
             index_type: IndexType::Char,
-            kind_prefix: true,
+            severity_prefix: true,
         }
     }
 }

--- a/src/write.rs
+++ b/src/write.rs
@@ -453,8 +453,7 @@ impl<S: Span> Report<'_, S> {
         if self.config.kind_prefix {
             let id = format!("{}{}:", Show(code), self.kind);
             writeln!(w, "{} {}", id.fg(kind_color, s), Show(self.msg.as_ref()))?;
-        } else if code.is_some() {
-            let id = format!("{}", Show(code));
+        } else if let Some(id) = code {
             writeln!(w, "{}{}", id.fg(kind_color, s), Show(self.msg.as_ref()))?;
         } else {
             writeln!(w, "{}", Show(self.msg.as_ref()))?;

--- a/src/write.rs
+++ b/src/write.rs
@@ -450,7 +450,7 @@ impl<S: Span> Report<'_, S> {
             ReportKind::Advice => self.config.advice_color(),
             ReportKind::Custom(_, color) => Some(color),
         };
-        if self.config.kind_prefix {
+        if self.config.severity_prefix {
             let id = format!("{}{}:", Show(code), self.kind);
             writeln!(w, "{} {}", id.fg(kind_color, s), Show(self.msg.as_ref()))?;
         } else if let Some(id) = code {
@@ -1867,10 +1867,10 @@ mod tests {
     }
 
     #[test]
-    fn no_kind_prefix() {
+    fn no_severity_prefix() {
         let msg = remove_trailing(
             Report::build(ReportKind::Error, 0..0)
-                .with_config(no_color_and_ascii().with_kind_prefix(false))
+                .with_config(no_color_and_ascii().with_severity_prefix(false))
                 .with_message("can't compare apples with oranges")
                 .finish()
                 .write_to_string(Source::from("")),
@@ -1881,10 +1881,10 @@ mod tests {
     }
 
     #[test]
-    fn no_kind_prefix_with_code() {
+    fn no_severity_prefix_with_code() {
         let msg = remove_trailing(
             Report::build(ReportKind::Error, 0..0)
-                .with_config(no_color_and_ascii().with_kind_prefix(false))
+                .with_config(no_color_and_ascii().with_severity_prefix(false))
                 .with_code("E001")
                 .with_message("can't compare apples with oranges")
                 .finish()
@@ -1896,11 +1896,11 @@ mod tests {
     }
 
     #[test]
-    fn no_kind_prefix_with_labels() {
+    fn no_severity_prefix_with_labels() {
         let source = "apple == orange;";
         let msg = remove_trailing(
             Report::build(ReportKind::Error, 0..0)
-                .with_config(no_color_and_ascii().with_kind_prefix(false))
+                .with_config(no_color_and_ascii().with_severity_prefix(false))
                 .with_message("can't compare apples with oranges")
                 .with_label(Label::new(0..5).with_message("This is an apple"))
                 .with_label(Label::new(9..15).with_message("This is an orange"))

--- a/src/write.rs
+++ b/src/write.rs
@@ -444,14 +444,21 @@ impl<S: Span> Report<'_, S> {
         // --- Header ---
 
         let code = self.code.as_ref().map(|c| format!("[{}] ", c));
-        let id = format!("{}{}:", Show(code), self.kind);
         let kind_color = match self.kind {
             ReportKind::Error => self.config.error_color(),
             ReportKind::Warning => self.config.warning_color(),
             ReportKind::Advice => self.config.advice_color(),
             ReportKind::Custom(_, color) => Some(color),
         };
-        writeln!(w, "{} {}", id.fg(kind_color, s), Show(self.msg.as_ref()))?;
+        if self.config.kind_prefix {
+            let id = format!("{}{}:", Show(code), self.kind);
+            writeln!(w, "{} {}", id.fg(kind_color, s), Show(self.msg.as_ref()))?;
+        } else if code.is_some() {
+            let id = format!("{}", Show(code));
+            writeln!(w, "{}{}", id.fg(kind_color, s), Show(self.msg.as_ref()))?;
+        } else {
+            writeln!(w, "{}", Show(self.msg.as_ref()))?;
+        }
 
         let groups = self.get_source_groups(&mut cache);
 
@@ -1858,5 +1865,59 @@ mod tests {
           | Note 2: Yeah, really, please stop.
           |         It has no resemblance2.
         ")
+    }
+
+    #[test]
+    fn no_kind_prefix() {
+        let msg = remove_trailing(
+            Report::build(ReportKind::Error, 0..0)
+                .with_config(no_color_and_ascii().with_kind_prefix(false))
+                .with_message("can't compare apples with oranges")
+                .finish()
+                .write_to_string(Source::from("")),
+        );
+        assert_snapshot!(msg, @r###"
+        can't compare apples with oranges
+        "###)
+    }
+
+    #[test]
+    fn no_kind_prefix_with_code() {
+        let msg = remove_trailing(
+            Report::build(ReportKind::Error, 0..0)
+                .with_config(no_color_and_ascii().with_kind_prefix(false))
+                .with_code("E001")
+                .with_message("can't compare apples with oranges")
+                .finish()
+                .write_to_string(Source::from("")),
+        );
+        assert_snapshot!(msg, @r###"
+        [E001] can't compare apples with oranges
+        "###)
+    }
+
+    #[test]
+    fn no_kind_prefix_with_labels() {
+        let source = "apple == orange;";
+        let msg = remove_trailing(
+            Report::build(ReportKind::Error, 0..0)
+                .with_config(no_color_and_ascii().with_kind_prefix(false))
+                .with_message("can't compare apples with oranges")
+                .with_label(Label::new(0..5).with_message("This is an apple"))
+                .with_label(Label::new(9..15).with_message("This is an orange"))
+                .finish()
+                .write_to_string(Source::from(source)),
+        );
+        assert_snapshot!(msg, @r###"
+        can't compare apples with oranges
+           ,-[ <unknown>:1:1 ]
+           |
+         1 | apple == orange;
+           | ^^|^^    ^^^|^^
+           |   `-------------- This is an apple
+           |             |
+           |             `---- This is an orange
+        ---'
+        "###)
     }
 }


### PR DESCRIPTION

Adds a `Config` option to omit the severity prefix (`Error:`, `Warning:`, etc.) from rendered output, so consumers like rolldown can apply the correct prefix downstream.

Closes #14.

```rust
Config::default().with_severity_prefix(false)
```

Default is `true` — no behavior change for existing callers.
