### PR TITLE
chore: pin GitHub Actions to commit SHAs

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -16,7 +16,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
     - name: Build
       run: cargo build --verbose
     - name: Run tests
@@ -25,9 +25,9 @@ jobs:
   cargo-fmt-check:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
       - name: Install toolchain
-        uses: dtolnay/rust-toolchain@master
+        uses: dtolnay/rust-toolchain@e97e2d8cc328f1b50210efc529dca0028893a2d9 # v1
         with:
           toolchain: ${{ env.RUST_VERSION }}
           components: rustfmt
@@ -37,12 +37,12 @@ jobs:
   cargo-clippy:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
       - name: Install toolchain
-        uses: dtolnay/rust-toolchain@master
+        uses: dtolnay/rust-toolchain@e97e2d8cc328f1b50210efc529dca0028893a2d9 # v1
         with:
           toolchain: ${{ env.RUST_VERSION }}
           components: clippy
-      - uses: Swatinem/rust-cache@v2
+      - uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
       - name: Check Clippy Linter
         run: cargo clippy --all-features --all-targets -- -D warnings

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -8,28 +8,28 @@ on:
 
 env:
   CARGO_TERM_COLOR: always
-  RUST_VERSION: 1.85.0
 
 jobs:
   build:
-
     runs-on: ubuntu-latest
-
     steps:
-    - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
-    - name: Build
-      run: cargo build --verbose
-    - name: Run tests
-      run: cargo test --verbose
+      - uses: taiki-e/checkout-action@7d1e50e93dc4fb3bba58f85018fadf77898aee8b # v1.4.2
+      - uses: oxc-project/setup-rust@23f38cfb0c04af97a055f76acee94d5be71c7c82 # v1.0.16
+        with:
+          cache-key: build
+          save-cache: ${{ github.ref_name == 'main' }}
+      - name: Build
+        run: cargo build --verbose
+      - name: Run tests
+        run: cargo test --verbose
 
   cargo-fmt-check:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
-      - name: Install toolchain
-        uses: dtolnay/rust-toolchain@e97e2d8cc328f1b50210efc529dca0028893a2d9 # v1
+      - uses: taiki-e/checkout-action@7d1e50e93dc4fb3bba58f85018fadf77898aee8b # v1.4.2
+      - uses: oxc-project/setup-rust@23f38cfb0c04af97a055f76acee94d5be71c7c82 # v1.0.16
         with:
-          toolchain: ${{ env.RUST_VERSION }}
+          restore-cache: false
           components: rustfmt
       - name: Check Formatting
         run: cargo fmt --all -- --check
@@ -37,12 +37,11 @@ jobs:
   cargo-clippy:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
-      - name: Install toolchain
-        uses: dtolnay/rust-toolchain@e97e2d8cc328f1b50210efc529dca0028893a2d9 # v1
+      - uses: taiki-e/checkout-action@7d1e50e93dc4fb3bba58f85018fadf77898aee8b # v1.4.2
+      - uses: oxc-project/setup-rust@23f38cfb0c04af97a055f76acee94d5be71c7c82 # v1.0.16
         with:
-          toolchain: ${{ env.RUST_VERSION }}
+          cache-key: clippy
+          save-cache: ${{ github.ref_name == 'main' }}
           components: clippy
-      - uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
       - name: Check Clippy Linter
         run: cargo clippy --all-features --all-targets -- -D warnings


### PR DESCRIPTION
## Summary

Org policy requires all actions to be pinned to a full-length commit SHA — the current workflow uses tags (`@v3`, `@master`, `@v2`) which fails CI with:

> Error: The action `actions/checkout@v3` is not allowed in rolldown/ariadne because all actions must be pinned to a full-length commit SHA.

Aligns the workflow with rolldown/rolldown's pinned actions (same SHAs, same versions):

| Action | Before | After |
|---|---|---|
| checkout | `actions/checkout@v3` | `taiki-e/checkout-action@7d1e50e9…` (v1.4.2) |
| rust setup | `dtolnay/rust-toolchain@master` + `Swatinem/rust-cache@v2` | `oxc-project/setup-rust@23f38cfb…` (v1.0.16) |

`oxc-project/setup-rust` replaces both the toolchain installer and the cache action, and reads the toolchain channel from `rust-toolchain.toml` (already at 1.87.0), so the unused `RUST_VERSION` env var is dropped.

## Test plan

- [ ] CI on this PR passes (build / cargo-fmt-check / cargo-clippy)
- [ ] After merge, rebase #15 and confirm its CI also runs cleanly

🤖 Generated with [Claude Code](https://claude.com/claude-code)