### PR TITLE
chore: release v0.6.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+# [0.6.0] - 2026-04-29
+
+### Added
+
+- Render help/note messages even when a report has no labels (#10)
+
+### Changed
+
+- Refactored notes rendering (#11)
+
 # [0.5.1] - 2025-03-13
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -88,7 +88,7 @@ checksum = "42f5e15c9953c5e4ccceeb2e7382a716482c34515315f7b03532b8b4e8393d2d"
 
 [[package]]
 name = "rolldown-ariadne"
-version = "0.5.2"
+version = "0.6.0"
 dependencies = [
  "concolor",
  "insta",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rolldown-ariadne"
-version = "0.5.2"
+version = "0.6.0"
 description = "A fork of github.com/zesterer/ariadne"
 authors = ["Joshua Barretto <joshua.s.barretto@gmail.com>"]
 license = "MIT"


### PR DESCRIPTION
## Summary

Release prep for **v0.6.0** (minor bump, 0.5.2 → 0.6.0).

- Bump version in `Cargo.toml` and `Cargo.lock`
- Add `[0.6.0] - 2026-04-29` entry to `CHANGELOG.md` covering changes since `v0.5.2`:
  - **Added:** Render help/note messages even when a report has no labels (#10)
  - **Changed:** Refactored notes rendering (#11)

## Post-merge release steps

- [ ] `git tag v0.6.0 && git push origin v0.6.0`
- [ ] `cargo publish`

🤖 Generated with [Claude Code](https://claude.com/claude-code)