### PR TITLE
chore: bump Rust toolchain to 1.95.0

### DIFF
--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,4 +1,3 @@
 [toolchain]
-channel = "1.87.0"
+channel = "1.95.0"
 profile = "default"
-

--- a/src/source.rs
+++ b/src/source.rs
@@ -428,7 +428,7 @@ mod tests {
         assert_eq!(source.lines.len(), lines.len());
 
         let mut offset = 0;
-        for (source_line, raw_line) in zip(source.lines.iter().copied(), lines.into_iter()) {
+        for (source_line, raw_line) in zip(source.lines.iter().copied(), lines) {
             assert_eq!(source_line.offset, offset);
             assert_eq!(source_line.char_len, raw_line.chars().count());
             assert_eq!(source.get_line_text(source_line).unwrap(), raw_line);

--- a/src/write.rs
+++ b/src/write.rs
@@ -74,7 +74,7 @@ struct SourceGroup<'a, S: Span> {
 }
 
 impl<S: Span> Report<'_, S> {
-    fn get_source_groups(&self, cache: &mut impl Cache<S::SourceId>) -> Vec<SourceGroup<S>> {
+    fn get_source_groups(&self, cache: &mut impl Cache<S::SourceId>) -> Vec<SourceGroup<'_, S>> {
         let mut groups = Vec::new();
         for label in self.labels.iter() {
             let label_source = label.span.source();


### PR DESCRIPTION
## Summary

Bump `rust-toolchain.toml` channel from `1.87.0` → `1.95.0` to match rolldown/rolldown's pinned channel (latest stable).

## Test plan

- [ ] CI build / cargo-fmt-check / cargo-clippy pass on 1.95.0

🤖 Generated with [Claude Code](https://claude.com/claude-code)